### PR TITLE
Generate migrations at runtime, use CNPG operator for database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add caddy tini
 ENV UV_NO_DEV=1
 ENV PYTHONUNBUFFERED=1
 
-RUN adduser -S -s /sbin/nologin rctf
+RUN adduser -S -s /sbin/nologin bctf
 
 # Sync the project into a new environment, asserting the lockfile is up to date
 WORKDIR /app
@@ -19,7 +19,7 @@ RUN uv sync --locked
 # Copy the project into the image
 COPY . /app
 
-RUN chown -R rctf /app
+RUN chown -R bctf /app
 USER rctf
 
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,20 @@ RUN apk add caddy tini
 ENV UV_NO_DEV=1
 ENV PYTHONUNBUFFERED=1
 
-RUN adduser -S -s /sbin/nologin app
+RUN adduser -S -s /sbin/nologin rctf
 
 # Sync the project into a new environment, asserting the lockfile is up to date
 WORKDIR /app
+
 COPY pyproject.toml uv.lock /app
 RUN uv sync --locked
 
 # Copy the project into the image
 COPY . /app
 
-USER app
+RUN chown -R rctf /app
+USER rctf
+
 EXPOSE 8000
 EXPOSE 8001
 CMD ["tini", "-g", "--", "/app/container-aux/entrypoint.sh"]

--- a/charts/manifest.yaml
+++ b/charts/manifest.yaml
@@ -1,14 +1,16 @@
-apiVersion: v1
-kind: Secret
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
 metadata:
   name: beaverctf-db
-type: Opaque
-stringData:
-  BCTF_DB_HOST: beavercds_pg
-  #BCTF_DB_PORT
-  BCTF_DB_USERNAME:
-  BCTF_DB_PASSWORD:
-  BCTF_DB_NAME:
+spec:
+  instances: 1
+  storage:
+    size: 1Gi
+  bootstrap:
+    initdb:
+      database: rctf
+      owner: rctf
 
 ---
 apiVersion: v1
@@ -62,9 +64,34 @@ spec:
               uv run manage.py migrate --noinput
           envFrom:
             - secretRef:
-                name: beaverctf-db
-            - secretRef:
                 name: beaverctf-secrets
+          # db secrets from CNPG operator
+          env: &db_cred_env
+            - name: BCTF_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: beaverctf-db-app
+                  key: host
+            - name: BCTF_DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: beaverctf-db-app
+                  key: port
+            - name: BCTF_DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: beaverctf-db-app
+                  key: username
+            - name: BCTF_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: beaverctf-db-app
+                  key: password
+            - name: BCTF_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: beaverctf-db-app
+                  key: dbname
 
       containers:
         - name: frontend
@@ -76,9 +103,8 @@ spec:
               containerPort: 8001
           envFrom:
             - secretRef:
-                name: beaverctf-db
-            - secretRef:
                 name: beaverctf-secrets
+          env: *db_cred_env
           volumeMounts:
             - name: config
               mountPath: /app/bctf/helm_settings.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       retries: 3
 
   app:
+    image: ghcr.io/osusec/beavercds-frontend:local
     build: .
     environment: &django_env
       # BCTF_DEBUG: false
@@ -44,13 +45,13 @@ services:
         condition: service_healthy
 
   migrations:
+    image: ghcr.io/osusec/beavercds-frontend:local
     build: .
     environment: *django_env
     command:
       - sh
       - -c
       - |
-        cat bctf/helm_settings.py
         uv run manage.py makemigrations --noinput
         uv run manage.py migrate --noinput
     depends_on:


### PR DESCRIPTION
Migrations needs access to database and a writable directory to output the migration files, so write out the migration files at runtime before applying.
